### PR TITLE
Camel case update and removal of itemnumber as mandatory

### DIFF
--- a/WebAPI/HttpREST/medius-openAPI.json
+++ b/WebAPI/HttpREST/medius-openAPI.json
@@ -12267,7 +12267,6 @@
           "codingLines",
           "externalSystemId",
           "isActive",
-          "itemNumber",
           "lineNumber",
           "quantity",
           "unit",


### PR DESCRIPTION
Item number was mandatory in spec but not in reality. Medius default to a - if the item number is not provided.
All API:s was not aligned with Camel case, this was fixed also.