### PR TITLE
Update S2C API

### DIFF
--- a/WebAPI/HttpREST/s2c-openAPI.json
+++ b/WebAPI/HttpREST/s2c-openAPI.json
@@ -542,7 +542,7 @@
       "ApiKeyAuth": {
         "type": "apiKey",
         "in": "header",
-        "name": "X-API-Key"
+        "name": "Authorization"
       }
     },
     "schemas": {


### PR DESCRIPTION
Update the authentication header key value to match what is set in the S2C configuration by default.