### PR TITLE
Add 'AccountDescription' and 'Default' fields to CompanyRelationshipPaymentDetailsDto schema

### DIFF
--- a/WebAPI/HttpREST/medius-openAPI.json
+++ b/WebAPI/HttpREST/medius-openAPI.json
@@ -26482,6 +26482,14 @@
           "paymentMethod": {
             "type": "string",
             "nullable": true
+          },
+          "accountDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "default": {
+            "type": "boolean",
+            "description": "Indicates whether this payment detail is the default for the company relationship."
           }
         },
         "additionalProperties": false


### PR DESCRIPTION
i mainly wanted to add 'Default' field to CompanyRelationshipPaymentDetailsDto schema, but found out 'AccountDescription' was missing too so i added both.