### PR TITLE
MFD-69344 Add Order Type to Purchase Order Line level

### DIFF
--- a/WebAPI/HttpREST/medius-openAPI.json
+++ b/WebAPI/HttpREST/medius-openAPI.json
@@ -12673,6 +12673,12 @@
               "name": "IsTwoWayMatch"
             }
           },
+          "orderType": {
+            "type": "string",
+            "xml": {
+              "name": "OrderType"
+            }
+          },
           "codingLines": {
             "type": "array",
             "xml": {
@@ -14253,6 +14259,17 @@
             "xml": {
               "name": "TwoWayMatchTotalInvoicedQuantity"
             }
+          },
+          "orderType": {
+            "type": "string",
+            "description": "If the order line should be treated as internal or external order line in Medius. T=external (default), M=internal.",
+            "xml": {
+              "name": "OrderType"
+            },
+            "enum": [
+              "T",
+              "M"
+            ]
           },
           "additionalItemNumbers": {
             "type": "array",


### PR DESCRIPTION
Related tasks:  
- [MFD-62265 Support for order types on line level - import](https://medius.atlassian.net/browse/MFD-62265)
- [MFD-69344 Support for order types on line level - PO export API](https://medius.atlassian.net/browse/MFD-69344)